### PR TITLE
Relax condition to emit back pc for Pandar64

### DIFF
--- a/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
+++ b/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
@@ -885,9 +885,14 @@ void PandarGeneral_Internal::ProcessLiarPacket() {
                start_angle_ <= pkt.blocks[i].azimuth) ||
               (last_azimuth_ < start_angle_ &&
                start_angle_ <= pkt.blocks[i].azimuth)) {
-            if (pcl_callback_ &&
-                (iPointCloudIndex > 0 || PointCloudList[0].size() > 0)) {
-              EmitBackMessege(pkt.header.chLaserNumber, outMsg);
+            if (pcl_callback_) {
+              // On every revolution, always send back the point cloud.
+              // This implies that some lasers/rings may not have a point but that is okay.
+              if (pcl_type_) {
+                EmitBackMessege(pkt.header.chLaserNumber, outMsg);
+              } else if (iPointCloudIndex > 0) {
+                EmitBackMessege(pkt.header.chLaserNumber, outMsg);
+              }
             }
           }
         } else {


### PR DESCRIPTION
Previously the point cloud back would only be emitted if ring 0 (the top most ring for Pandar64) would have a point. This implied that in open scenes where ring 0 has no points within 0.1 and 200m, no point cloud would be emitted back by the SDK.

Here we change the logic so that we always emit back a point cloud regardless of points being in ring 0 or not.